### PR TITLE
feat(error): Switch items on error if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,21 @@ meisterPlayer.setItem({
 
 meisterPlayer.load();
 ```
+
+### switchItemOnError *[Boolean]* (default: true) ###
+
+Goes to the next item in the 'sources' array when the current item has thrown an error. (NOT_FOUND, CODEC_ERRORS, etc) 
+This can be usefull for codecs that cannot be determined if it can play on the current device.
+Multisource will switch out the item with a new item so playback can continue.
+
+Example:
+
+``` JavaScript
+meisterPlayer.setItem({
+    sources: [ ... ],
+    type: 'multi-source',
+    switchItemOnError: false, // Will stop playback after an fatal error occured.
+});
+```
+
+

--- a/src/js/MultiSource.js
+++ b/src/js/MultiSource.js
@@ -54,6 +54,10 @@ class MultiSource extends Meister.ParserPlugin {
     }
 
     process(item) {
+        if (item.src && !item.sources) {
+            item.sources = item.src;
+        }
+
         this.currentItem = item;
 
         // Set default config

--- a/src/js/MultiSource.js
+++ b/src/js/MultiSource.js
@@ -56,6 +56,11 @@ class MultiSource extends Meister.ParserPlugin {
     process(item) {
         this.currentItem = item;
 
+        // Set default config
+        if (typeof this.currentItem.switchItemOnError === 'undefined') {
+            this.currentItem.switchItemOnError = true;
+        }
+
         return new Promise((resolve, reject) => {
             const hasDRM = typeof item.drmConfig === 'object';
             item.sources = this.restructureItems(item.sources, hasDRM); // eslint-disable-line
@@ -68,7 +73,9 @@ class MultiSource extends Meister.ParserPlugin {
                         newItem.metadata = item.metadata; // eslint-disable-line
                     }
 
-                    this.on('playerError', this.onPlayerError.bind(this));
+                    if (this.currentItem.switchItemOnError) {
+                        this.on('playerError', this.onPlayerError.bind(this));
+                    }
 
                     resolve(newItem);
                 }


### PR DESCRIPTION
When a player error occurred we can switch our multisource item. This is useful four codecs that we can only know if it works by playing the item. It's surprisingly very fast doing the switch, it's almost not noticeable for the user that a swap is being done.

closes https://github.com/meisterplayer/meisterplayer/issues/55